### PR TITLE
Implement chat history with persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/ge/azvonov/notesai/ChatController.java
+++ b/src/main/java/ge/azvonov/notesai/ChatController.java
@@ -6,6 +6,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import ge.azvonov.notesai.ChatMessage;
+import ge.azvonov.notesai.ChatMessageRepository;
+
+import java.util.List;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -13,8 +19,17 @@ import java.nio.charset.StandardCharsets;
 @Controller
 public class ChatController {
 
+    private final ChatMessageRepository repository;
+
+    @Autowired
+    public ChatController(ChatMessageRepository repository) {
+        this.repository = repository;
+    }
+
     @GetMapping("/chat")
-    public String chat() {
+    public String chat(Model model) {
+        List<ChatMessage> messages = repository.findAll();
+        model.addAttribute("messages", messages);
         return "chat";
     }
 
@@ -28,8 +43,17 @@ public class ChatController {
             fileName = file.getOriginalFilename();
             fileContent = new String(file.getBytes(), StandardCharsets.UTF_8);
         }
-        model.addAttribute("response", "Вы сказали: " + message + ", файл: " + fileName);
+        String responseText = "Вы сказали: " + message + ", файл: " + fileName;
+        model.addAttribute("response", responseText);
         model.addAttribute("fileContent", fileContent);
+
+        ChatMessage chatMessage = new ChatMessage();
+        chatMessage.setMessage(message);
+        chatMessage.setResponse(responseText);
+        repository.save(chatMessage);
+
+        List<ChatMessage> messages = repository.findAll();
+        model.addAttribute("messages", messages);
         return "chat";
     }
 }

--- a/src/main/java/ge/azvonov/notesai/ChatMessage.java
+++ b/src/main/java/ge/azvonov/notesai/ChatMessage.java
@@ -1,0 +1,45 @@
+package ge.azvonov.notesai;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+public class ChatMessage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String message;
+
+    private String response;
+
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String response) {
+        this.response = response;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/ge/azvonov/notesai/ChatMessageRepository.java
+++ b/src/main/java/ge/azvonov/notesai/ChatMessageRepository.java
@@ -1,0 +1,6 @@
+package ge.azvonov.notesai;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=update

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -15,5 +15,13 @@
     <p th:text="${response}"></p>
     <pre th:if="${fileContent}" th:text="${fileContent}"></pre>
 </div>
+<h2>История сообщений</h2>
+<ul>
+    <li th:each="msg : ${messages}">
+        <span th:text="${msg.timestamp}"></span> :
+        <strong th:text="${msg.message}"></strong>
+        <em th:text="${msg.response}"></em>
+    </li>
+</ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use JPA and H2 for persistence
- store chat messages and responses
- display all stored messages on the chat page

## Testing
- `mvn -q -DskipTests=true package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bdce76a483228e40e24169973b68