### PR TITLE
Add OpenAI embedding service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
             <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.openai</groupId>
+            <artifactId>openai-java</artifactId>
+            <version>2.4.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/ge/azvonov/notesai/EmbeddingService.java
+++ b/src/main/java/ge/azvonov/notesai/EmbeddingService.java
@@ -1,0 +1,43 @@
+package ge.azvonov.notesai;
+
+import com.openai.client.OpenAI;
+import com.openai.client.embeddings.EmbeddingsRequest;
+import com.openai.client.embeddings.EmbeddingsResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class EmbeddingService {
+
+    private static final int CHUNK_SIZE = 500;
+
+    private final OpenAI openAI;
+
+    public EmbeddingService(@Value("${openai.api.key}") String apiKey) {
+        this.openAI = new OpenAI(apiKey);
+    }
+
+    public List<TextEmbedding> embedText(String content) {
+        List<TextEmbedding> result = new ArrayList<>();
+        for (int pos = 0; pos < content.length(); pos += CHUNK_SIZE) {
+            String chunk = content.substring(pos, Math.min(pos + CHUNK_SIZE, content.length()));
+            List<Double> vector = fetchEmbedding(chunk);
+            result.add(new TextEmbedding(chunk, vector));
+        }
+        return result;
+    }
+
+    private List<Double> fetchEmbedding(String text) {
+        EmbeddingsRequest request = EmbeddingsRequest.builder()
+                .model("text-embedding-ada-002")
+                .input(List.of(text))
+                .build();
+        EmbeddingsResponse response = openAI.embeddings().create(request);
+        return response.getData().get(0).getEmbedding();
+    }
+
+    public record TextEmbedding(String text, List<Double> vector) {}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.h2.console.enabled=true
 spring.jpa.hibernate.ddl-auto=update
+openai.api.key=YOUR_OPENAI_API_KEY


### PR DESCRIPTION
## Summary
- implement `EmbeddingService` for OpenAI Embeddings API
- add placeholder API key property
- refactor service to use `openai-client` library

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c1c819f88322a5bd716812e5c481