### PR TITLE
User-specific projects and chat

### DIFF
--- a/src/main/java/ge/azvonov/notesai/ChatMessage.java
+++ b/src/main/java/ge/azvonov/notesai/ChatMessage.java
@@ -17,6 +17,10 @@ public class ChatMessage {
     @JoinColumn(name = "project_id")
     private Project project;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private AppUser user;
+
     private LocalDateTime timestamp = LocalDateTime.now();
 
     public Long getId() {
@@ -45,6 +49,14 @@ public class ChatMessage {
 
     public void setProject(Project project) {
         this.project = project;
+    }
+
+    public AppUser getUser() {
+        return user;
+    }
+
+    public void setUser(AppUser user) {
+        this.user = user;
     }
 
     public LocalDateTime getTimestamp() {

--- a/src/main/java/ge/azvonov/notesai/Project.java
+++ b/src/main/java/ge/azvonov/notesai/Project.java
@@ -10,9 +10,17 @@ public class Project {
 
     private String name;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private AppUser user;
+
     public Long getId() { return id; }
 
     public String getName() { return name; }
 
     public void setName(String name) { this.name = name; }
+
+    public AppUser getUser() { return user; }
+
+    public void setUser(AppUser user) { this.user = user; }
 }

--- a/src/main/java/ge/azvonov/notesai/db/ChatMessageRepository.java
+++ b/src/main/java/ge/azvonov/notesai/db/ChatMessageRepository.java
@@ -1,7 +1,10 @@
 package ge.azvonov.notesai.db;
 
 import ge.azvonov.notesai.ChatMessage;
+import ge.azvonov.notesai.AppUser;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+    List<ChatMessage> findByUser(AppUser user);
 }

--- a/src/main/java/ge/azvonov/notesai/db/ProjectRepository.java
+++ b/src/main/java/ge/azvonov/notesai/db/ProjectRepository.java
@@ -1,7 +1,10 @@
 package ge.azvonov.notesai.db;
 
 import ge.azvonov.notesai.Project;
+import ge.azvonov.notesai.AppUser;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
+    List<Project> findByUser(AppUser user);
 }

--- a/src/main/resources/db/changelog/004-ownership.xml
+++ b/src/main/resources/db/changelog/004-ownership.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="8" author="codex">
+        <addColumn tableName="project">
+            <column name="user_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="project"
+                                 baseColumnNames="user_id"
+                                 referencedTableName="app_user"
+                                 referencedColumnNames="id"
+                                 constraintName="fk_project_user"/>
+    </changeSet>
+
+    <changeSet id="9" author="codex">
+        <addColumn tableName="chat_message">
+            <column name="user_id" type="BIGINT"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="chat_message"
+                                 baseColumnNames="user_id"
+                                 referencedTableName="app_user"
+                                 referencedColumnNames="id"
+                                 constraintName="fk_chat_message_user"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -8,5 +8,6 @@
     <include file="classpath:db/changelog/001-init.xml"/>
     <include file="classpath:db/changelog/002-pgvector.xml"/>
     <include file="classpath:db/changelog/003-users.xml"/>
+    <include file="classpath:db/changelog/004-ownership.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -12,7 +12,8 @@
 </form>
 <form method="post" enctype="multipart/form-data" th:action="@{/chat}">
     <select name="projectId">
-        <option th:each="p : ${projects}" th:value="${p.id}" th:text="${p.name}"></option>
+        <option th:each="p : ${projects}" th:value="${p.id}" th:text="${p.name}"
+                th:selected="${p.id == selectedProjectId}"></option>
     </select>
     <input type="text" name="message" placeholder="Сообщение" />
     <input type="file" name="file" />


### PR DESCRIPTION
## Summary
- associate projects and chat messages with their owners
- display only user-related data in chat and project management
- keep selected project after sending a message
- add Liquibase changelog for new relations

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846b2c39e908322944df4828a040940