### PR TITLE
Move file management to project page

### DIFF
--- a/src/main/java/ge/azvonov/notesai/ChatController.java
+++ b/src/main/java/ge/azvonov/notesai/ChatController.java
@@ -17,13 +17,11 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 @Controller
 public class ChatController {
@@ -76,28 +74,10 @@ public class ChatController {
     @PostMapping("/chat")
     public String handleChat(@RequestParam("message") String message,
                              @RequestParam("projectId") Long projectId,
-                             @RequestParam(value = "file", required = false) MultipartFile file,
                              Model model) throws IOException {
         AppUser user = currentUser();
-        String fileName = "без файла";
-        String fileContent = null;
-        if (file != null && !file.isEmpty()) {
-            fileName = file.getOriginalFilename();
-            fileContent = new String(file.getBytes(), StandardCharsets.UTF_8);
-            String ext = "";
-            int dot = fileName.lastIndexOf('.');
-            if (dot >= 0) {
-                ext = fileName.substring(dot + 1);
-            }
-            long fileId = vectorService.saveFileMetadata(projectId, fileName, ext);
-            List<TextEmbedding> textEmbeddings = embeddingService.embedText(fileContent);
-            for (TextEmbedding chunk : textEmbeddings) {
-                vectorService.saveTextChunk(fileId, chunk.text(), chunk.vector());
-            }
-            int i = 0;
-        }
 
-        String responseText = "Вы сказали: " + message + ", файл: " + fileName;
+        String responseText = "Вы сказали: " + message;
         String answer = "";
 
         if (StringUtils.hasLength(message)) {

--- a/src/main/java/ge/azvonov/notesai/db/FileMetadata.java
+++ b/src/main/java/ge/azvonov/notesai/db/FileMetadata.java
@@ -1,0 +1,3 @@
+package ge.azvonov.notesai.db;
+
+public record FileMetadata(long id, String name, String extension) {}

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -10,13 +10,12 @@
 <form th:action="@{/logout}" method="post" style="display:inline;">
     <button type="submit">Выйти</button>
 </form>
-<form method="post" enctype="multipart/form-data" th:action="@{/chat}">
+<form method="post" th:action="@{/chat}">
     <select name="projectId">
         <option th:each="p : ${projects}" th:value="${p.id}" th:text="${p.name}"
                 th:selected="${p.id == selectedProjectId}"></option>
     </select>
     <input type="text" name="message" placeholder="Сообщение" />
-    <input type="file" name="file" />
     <button type="submit">Отправить</button>
 </form>
 <div th:if="${response}">

--- a/src/main/resources/templates/projects.html
+++ b/src/main/resources/templates/projects.html
@@ -15,6 +15,7 @@
         <th>ID</th>
         <th>Название</th>
         <th>Действия</th>
+        <th>Файлы</th>
     </tr>
     <tr th:each="proj : ${projects}">
         <td th:text="${proj.id}"></td>
@@ -25,6 +26,23 @@
                 <button type="submit">Удалить</button>
             </form>
             <a th:href="@{'/projects/edit/' + ${proj.id}}">Редактировать</a>
+        </td>
+        <td>
+            <form th:action="@{/projects/upload}" method="post" enctype="multipart/form-data" style="margin-bottom:5px;">
+                <input type="hidden" name="projectId" th:value="${proj.id}" />
+                <input type="file" name="file" />
+                <button type="submit">Загрузить</button>
+            </form>
+            <ul>
+                <li th:each="f : ${files[proj.id]}">
+                    <span th:text="${f.name}"></span>
+                    <form th:action="@{/projects/delete-file}" method="post" style="display:inline;">
+                        <input type="hidden" name="projectId" th:value="${proj.id}" />
+                        <input type="hidden" name="fileId" th:value="${f.id}" />
+                        <button type="submit">Удалить</button>
+                    </form>
+                </li>
+            </ul>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
## Summary
- add FileMetadata record for listing project files
- provide file listing and deletion in `VectorService`
- manage file uploads/deletes through `ProjectController`
- simplify chat controller and chat page to send only text
- show file management controls on project list page

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b5e15f7883229d582068dcc9423f